### PR TITLE
Delete slashes before relative paths

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,6 +8,6 @@
 <img src="images/jjcompany.png">
 <h3>Hmm...</h3><br/>
 It seems you are lost somewhere that doesn't exist...<br/>
-<a href="/index.html">Take me back home!</a>
+<a href="index.html">Take me back home!</a>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -13,6 +13,6 @@ As for efficiency:<br/>
 All main programs shipped with JOS are built into the Kernel itself, for fast loading,<br/>
 and the Kernel is lightweight, so it won't take up much ram, leaving plenty for loading programs.
 </p>
-<a href="/index.html">Take me back home!</a>
+<a href="index.html">Take me back home!</a>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
 <img src="images/jjcompany.png">
 <h1>JOS Website</h1>
 <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release">GitHub Repository</a><br/>
-<a href="/about.html">About</a>
+<a href="about.html">About</a>
 </body>
 </html>


### PR DESCRIPTION
The slashes before the relative paths make the browser (at least Firefox) treat it as an absolute path and it doesn't work offline with the file:/// URLs.
