### PR TITLE
Delete "Take me back home!" on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,5 @@ As for efficiency:<br/>
 All main programs shipped with JOS are built into the Kernel itself, for fast loading,<br/>
 and the Kernel is lightweight, so it won't take up much ram, leaving plenty for loading programs.
 </p>
-<a href="index.html">Take me back home!</a>
 </body>
 </html>


### PR DESCRIPTION
Since you can just click the image, it is no longer necessary. It still seems good on the 404 page though.
