### PR TITLE
Fix links etc

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,14 +2,14 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-	<link rel="stylesheet" type="text/css" href="stylesheet.css">
+	<link rel="stylesheet" type="text/css" href="http://jandjos.gq/stylesheet.css">
 	<title>Hmm...</title>
 </head>
 <body>
-	<h1><a href="index.html">JOS</a></h1>
-	<p><a href="about.html">About</a> | <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/emulator/JOSEmu.exe?raw=true">Download Emulator</a> | <a href="install.html">Install</a> | </a> <a href="links.html">Links</a></p>
+	<h1><a href="http://jandjos.gq/index.html">JOS</a></h1>
+	<p><a href="http://jandjos.gq/about.html">About</a> | <a href="http://jandjos.gq/install.html">Install</a> | </a> <a href="http://jandjos.gq/links.html">Links</a></p>
 	<h3>Hmm...</h3>
 	<p>It seems you are lost somewhere that doesn't exist...<br/>
-	<a href="index.html">Take me back home!</a></p>
+	<a href="http://jandjos.gq/index.html">Take me back home!</a></p>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 	<h1><a href="index.html">JOS</a></h1>
-	<p>About | <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/emulator/JOSEmu.exe?raw=true">Download Emulator</a> | <a href="install.html">Install</a> | </a> <a href="links.html">Links</a></p>
+	<p>About | <a href="install.html">Install</a> | </a> <a href="links.html">Links</a></p>
 	<p>
 		JOS is an operating system written entirely in FreeBASIC, which will soon be compiled to machine code.<br/>
 		This operating system is designed to be fast and efficient with loading programs, and writing them.<br/>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 	<h1>JOS</h1>
-	<p><a href="about.html">About</a> | <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/emulator/JOSEmu.exe?raw=true">Download Emulator</a> | <a href="install.html">Install</a> | </a> <a href="links.html">Links</a></p>
+	<p><a href="about.html">About</a> | <a href="install.html">Install</a> | </a> <a href="links.html">Links</a></p>
 	<p><a href="http://www.bing.com/images/search?q=easter+egg" style="cursor: text; color: black; text-decoration: none;">[insert contents]</a></p>
 	<a id="viewongh" href="https://github.com/J-and-J-Programming-Industries/web"><img src="images/viewongh.png"></a><span id="viewongh-desc" class="default-hidden"><br/>
 	<span class="bordered">View the repo &quot;web&quot; containing these pages</span></span>

--- a/install.html
+++ b/install.html
@@ -7,9 +7,9 @@
 </head>
 <body>
 	<h1><a href="index.html">JOS</a></h1>
-	<p><a href="about.html">About</a> | <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/emulator/JOSEmu.exe?raw=true">Download Emulator</a> | Install | </a> <a href="links.html">Links</a></p>
+	<p><a href="about.html">About</a> | Install | </a> <a href="links.html">Links</a></p>
 	<p>
-		Installing JOS is easy! You don't even need to wipe your hard drive! You can just download the <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/releases/JOS.exe?raw=true">Windows</a> version here as an executable, or the <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/releases/JOS?raw=true">Linux</a> version at the links, then running them!<br/>
+		Installing JOS is easy! You don&apos;t even need to wipe your hard drive! You can download the most recent version <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/releases">here</a>! (JOS for Linux, JOS.exe for Windows)<br/>
 		After you have downloaded them, double click on the .exe file on Windows, or type ./JOS in the terminal on Linux.<br/>
 		It is a command line based program, so your desktop will continue to run in the background.<br/>
 		All programs you have already will still work, as it does not replace your native OS.<br/>

--- a/install.html
+++ b/install.html
@@ -9,7 +9,7 @@
 	<h1><a href="index.html">JOS</a></h1>
 	<p><a href="about.html">About</a> | Install | </a> <a href="links.html">Links</a></p>
 	<p>
-		Installing JOS is easy! You don&apos;t even need to wipe your hard drive! You can download the most recent version <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/releases">here</a>! (JOS for Linux, JOS.exe for Windows)<br/>
+		Installing JOS is easy! You don&apos;t even need to wipe your hard drive! You can just download the most recent version <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/releases">here</a>! (JOS for Linux, JOS.exe for Windows)<br/>
 		After you have downloaded them, double click on the .exe file on Windows, or type ./JOS in the terminal on Linux.<br/>
 		It is a command line based program, so your desktop will continue to run in the background.<br/>
 		All programs you have already will still work, as it does not replace your native OS.<br/>

--- a/links.html
+++ b/links.html
@@ -7,25 +7,19 @@
 </head>
 <body>
 	<h1><a href="index.html">JOS</a></h1>
-	<p><a href="about.html">About</a> | <a href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/emulator/JOSEmu.exe?raw=true">Download Emulator</a> | <a href="install.html">Install</a> | Links</p>
+	<p><a href="about.html">About</a> | <a href="install.html">Install</a> | Links</p>
 	<a id="repo" href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release"><img src="images/repo.png"></a><span id="repo-desc" class="default-hidden"><br/>
-	<span class="bordered">View the repo &quot;JOSPre-Release&quot; containing JOS code and emulator</span></span><br/><br/>
-	<a id="download" href="https://github.com/J-and-J-Programming-Industries/JOSPre-Release/blob/master/emulator/JOSEmu.exe?raw=true"><img src="images/download.png"></a><span id="download-desc" class="default-hidden"><br/>
-	<span class="bordered">Download the JOS emulator &quot;JOSEmu.exe&quot;</span></span><br/><br/>
+	<span class="bordered">View the repo &quot;JOSPre-Release&quot; containing JOS code and downloads, click the releases button (with the tag icon) to see downloads</span></span><br/><br/>
 	<a id="jjcompany" href="http://jandjcompany.tk/"><img src="images/jjcompany.png"></a><span id="jjcompany-desc" class="default-hidden"><br/>
 	<span class="bordered">Visit the J&amp;J Company website</span></span><br/><br/>
-	<a id="scratch" href="https://scratch.mit.edu/projects/99561199/"><img src="images/scratch.png"></a><span id="scratch-desc" class="default-hidden"><br/>
-	<span class="bordered">View the JOS emulator created by savaka on Scratch</span></span><br/><br/>
+	<!-- <a id="scratch" href="https://scratch.mit.edu/projects/99561199/"><img src="images/scratch.png"></a><span id="scratch-desc" class="default-hidden"><br/>
+	<span class="bordered">View the JOS emulator created by savaka on Scratch</span></span><br/><br/> -->
 	<a id="viewongh" href="https://github.com/J-and-J-Programming-Industries/web"><img src="images/viewongh.png"></a><span id="viewongh-desc" class="default-hidden"><br/>
 	<span class="bordered">View the repo &quot;web&quot; containing these pages</span></span>
 </body>
 </html>
 <style>
 #repo:hover + #repo-desc {
-	display: initial;
-}
-
-#download:hover + #download-desc {
 	display: initial;
 }
 

--- a/links.html
+++ b/links.html
@@ -27,7 +27,9 @@
 	display: initial;
 }
 
+/*
 #scratch:hover + #scratch-desc {
 	display: initial;
 }
+*/
 </style>


### PR DESCRIPTION
Changes in this PR:
- Remove "Download Emulator" links in navigation bar
- 404 page needs absolute URLs in case of stuff like http://jandjos.gq/a/a/a
- Replace download links with link to releases page in install.html
- Replace `'` with `&apos;` in install.html
- Remove "Download Emulator" link and comment out "Emulator on Scratch" on links.html
- Remove new lines at end of file
